### PR TITLE
Bump udev from 0.4 to 0.5

### DIFF
--- a/mio-udev/Cargo.toml
+++ b/mio-udev/Cargo.toml
@@ -12,6 +12,6 @@ documentation = "https://docs.rs/mio-udev"
 edition = "2018"
 
 [dependencies]
-udev = "0.4"
+udev = "0.5"
 mio = "0.6"
 libc = "0.2"


### PR DESCRIPTION
https://github.com/Smithay/udev-rs/compare/v0.4.0...v0.5.0

It doesn't seem like there's any major changes here, but I thought I might as well PR this too while I'm upgrading stuff in #9 