### PR TITLE
tokio-udev: Remove `mio` dependency

### DIFF
--- a/tokio-udev/Cargo.toml
+++ b/tokio-udev/Cargo.toml
@@ -12,10 +12,9 @@ documentation = "https://docs.rs/tokio-udev"
 edition = "2018"
 
 [dependencies]
-mio = { version = "0.7", features = ["os-poll"] }
 futures-core = "0.3"
 tokio = { version = "1", features = ["net"] }
-udev = { version = "0.6", features = ["mio"] }
+udev = { version = "0.6" }
 
 [dev-dependencies]
 futures-util = "0.3"


### PR DESCRIPTION
With Tokio 1.0 and `AsyncFd`, `mio` isn't used directly, so this seems to be unnecessary.